### PR TITLE
[Bazel] Add loader and register

### DIFF
--- a/core/BUILD.bazel
+++ b/core/BUILD.bazel
@@ -93,7 +93,7 @@ public_headers = public_headers_no_gen + [
 ]
 
 cc_binary(
-    name = "libign_plugin.so",
+    name = "libignition-plugin2.so",
     srcs = [
         "src/EnablePluginFromThis.cc",
         "src/Factory.cc",
@@ -103,6 +103,7 @@ cc_binary(
         "src/WeakPluginPtr.cc"
     ] + public_headers,
     includes = ["include"],
+    linkopts = ["-Wl,-soname,libignition-plugin2.so"],
     linkshared = True,
     visibility = [],
     deps = [ "//ign_bazel:utilities" ]
@@ -110,7 +111,7 @@ cc_binary(
 
 cc_library(
     name = "ign_plugin",
-    srcs = ["libign_plugin.so"],
+    srcs = ["libignition-plugin2.so"],
     hdrs = public_headers,
     includes = ["include"],
     visibility = ["//visibility:public"],

--- a/core/BUILD.bazel
+++ b/core/BUILD.bazel
@@ -12,7 +12,7 @@ load(
 )
 
 
-PROJECT_NAME = "ignition-common"
+PROJECT_NAME = "ignition-plugin"
 PROJECT_MAJOR = 2
 PROJECT_MINOR = 0
 PROJECT_PATCH = 0

--- a/loader/BUILD.bazel
+++ b/loader/BUILD.bazel
@@ -18,7 +18,7 @@ sources = [
 ]
 
 test_sources = [
-    # "src/Loader_TEST.cc"
+    "src/Loader_TEST.cc"
 ]
 
 generate_file(
@@ -57,10 +57,10 @@ public_headers = public_headers_no_gen + [
 ]
 
 cc_binary(
-    name = "libign_plugin-loader.so",
+    name = "libignition-plugin2-loader.so",
     srcs = sources + public_headers,
     includes = ["include"],
-    linkopts = ["-Wl,-soname,libign_plugin-loader.so", "-ldl"],
+    linkopts = ["-Wl,-soname,libignition-plugin2-loader.so", "-ldl"],
     linkshared = True,
     visibility = [],
     deps = [
@@ -71,11 +71,15 @@ cc_binary(
 
 cc_library(
     name = "loader",
-    srcs = ["libign_plugin-loader.so"],
+    srcs = ["libignition-plugin2-loader.so"],
     hdrs = public_headers,
     includes = ["include"],
     visibility = ["//visibility:public"],
-    deps = [],
+    linkopts = ["-ldl"],
+    deps = [
+        "//ign_plugin/core:ign_plugin",
+        "//ign_bazel:utilities",
+    ],
 )
 
 [cc_test(
@@ -83,14 +87,11 @@ cc_library(
     srcs = [src],
     deps = [
         "//ign_bazel:utilities",
+        "//ign_common",
         "//ign_plugin/loader",
         "//ign_plugin/core:ign_plugin",
+        "//ign_plugin/test:IGNDummyPlugins.so",
         "@gtest//:gtest",
         "@gtest//:gtest_main",
-    ],
-    local_defines = [
-        "IGN_PLUGIN_SOURCE_DIR='\"TODO: set the correct path here\"'",
-        "IGN_PLUGIN_LIB='\"TODO: set the correct path here\"'",
-        "IGNDummyPlugins_LIB='\"TODO: set the correct path here\"'",
     ],
 ) for src in test_sources]

--- a/loader/BUILD.bazel
+++ b/loader/BUILD.bazel
@@ -1,0 +1,98 @@
+load(
+    "//ign_bazel:generate_include_header.bzl",
+    "generate_include_header",
+)
+
+load(
+    "//ign_bazel:generate_file.bzl",
+    "generate_file",
+)
+
+public_headers_no_gen = [
+    "include/ignition/plugin/Loader.hh",
+    "include/ignition/plugin/detail/Loader.hh",
+]
+
+sources = [
+    "src/Loader.cc"
+]
+
+test_sources = [
+    "src/Loader_TEST.cc"
+]
+
+generate_file(
+    name = "include/ignition/plugin/loader/Export.hh",
+    content = """
+#pragma once
+// IGN_DEPRECATED is defined by all ignition libraries, but the version below
+// is a simplified version.  When mixing the regular ignition libraries and
+// the drake compiled ignition libraries, the compiler throws a warning about
+// the macro being multiply defined.  We undefine it before redefining it here
+// to work around that issue.  Note that the IGNITION_PLUGIN_LOADER_VISIBLE macro
+// shouldn't be defined multiple times, but we undefine it just in case.
+#ifdef IGNITION_PLUGIN_LOADER_VISIBLE
+#undef IGNITION_PLUGIN_LOADER_VISIBLE
+#endif
+#define IGNITION_PLUGIN_LOADER_VISIBLE __attribute__ ((visibility("default")))
+#ifdef IGN_DEPRECATED
+#undef IGN_DEPRECATED
+#endif
+#define IGN_DEPRECATED(version) __attribute__ ((__deprecated__))
+    """,
+    visibility = ["//visibility:private"],
+)
+
+generate_include_header(
+    name = "loader_hh_genrule",
+    out = "include/ignition/plugin/loader.hh",
+    hdrs = public_headers_no_gen + [
+        "include/ignition/plugin/loader/Export.hh",
+    ],
+)
+
+public_headers = public_headers_no_gen + [
+    "include/ignition/plugin/loader/Export.hh",
+    "include/ignition/plugin/loader.hh",
+]
+
+cc_binary(
+    name = "libign_plugin-loader.so",
+    srcs = sources + public_headers,
+    includes = ["include"],
+    linkopts = ["-Wl,-soname,libign_plugin-loader.so", "-ldl"],
+    linkshared = True,
+    visibility = [],
+    deps = [
+        "//ign_plugin/core:ign_plugin",
+        "//ign_bazel:utilities",
+    ],
+)
+
+cc_library(
+    name = "loader",
+    srcs = ["libign_plugin-loader.so"],
+    hdrs = public_headers,
+    includes = ["include"],
+    visibility = ["//visibility:public"],
+    linkstatic = True,
+    alwayslink = 1,
+    deps = [],
+)
+
+[cc_test(
+    name = src.replace("/", "_").replace(".cc", "").replace("src_", ""),
+    srcs = [src],
+    deps = [
+        "//ign_bazel:utilities",
+        "//ign_plugin/loader",
+        "//ign_plugin/core:ign_plugin",
+        "@gtest//:gtest",
+        "@gtest//:gtest_main",
+    ],
+    local_defines = [
+        "IGN_PLUGIN_SOURCE_DIR='\"testing\"'",
+        "IGN_PLUGIN_LIB='\"testing\"'",
+        "IGNDummyPlugins_LIB='\"testing\"'",
+    ],
+) for src in test_sources]

--- a/loader/BUILD.bazel
+++ b/loader/BUILD.bazel
@@ -18,7 +18,7 @@ sources = [
 ]
 
 test_sources = [
-    "src/Loader_TEST.cc"
+    # "src/Loader_TEST.cc"
 ]
 
 generate_file(
@@ -75,8 +75,6 @@ cc_library(
     hdrs = public_headers,
     includes = ["include"],
     visibility = ["//visibility:public"],
-    linkstatic = True,
-    alwayslink = 1,
     deps = [],
 )
 

--- a/loader/BUILD.bazel
+++ b/loader/BUILD.bazel
@@ -91,8 +91,8 @@ cc_library(
         "@gtest//:gtest_main",
     ],
     local_defines = [
-        "IGN_PLUGIN_SOURCE_DIR='\"testing\"'",
-        "IGN_PLUGIN_LIB='\"testing\"'",
-        "IGNDummyPlugins_LIB='\"testing\"'",
+        "IGN_PLUGIN_SOURCE_DIR='\"TODO: set the correct path here\"'",
+        "IGN_PLUGIN_LIB='\"TODO: set the correct path here\"'",
+        "IGNDummyPlugins_LIB='\"TODO: set the correct path here\"'",
     ],
 ) for src in test_sources]

--- a/loader/src/Loader_TEST.cc
+++ b/loader/src/Loader_TEST.cc
@@ -18,11 +18,52 @@
 #include <gtest/gtest.h>
 
 #include <algorithm>
+#include <fstream>
+
+#include <ignition/common/Filesystem.hh>
+#include <ignition/common/Util.hh>
 
 #include <ignition/plugin/Loader.hh>
 #include <ignition/plugin/config.hh>
 
 #include <ignition/plugin/SpecializedPluginPtr.hh>
+
+
+/////////////////////////////////////////////////
+bool IgnPluginLib(std::string &_path)
+{
+#ifdef IGN_PLUGIN_LIB
+  _path = IGN_PLUGIN_LIB;
+  return true;
+#else
+  std::string dataDir;
+  if (ignition::common::env("TEST_SRCDIR", dataDir))
+  {
+    _path = ignition::common::joinPaths(dataDir,
+        "__main__/ign_plugin/core/libignition-plugin2.so");
+    return true;
+  }
+#endif
+  return false;
+}
+
+/////////////////////////////////////////////////
+bool IgnDummyPluginLib(std::string &_path)
+{
+#ifdef IGNDummyPlugins_LIB
+  _path = IGNDummyPlugins_LIB;
+  return true;
+#else
+  std::string dataDir;
+  if (ignition::common::env("TEST_SRCDIR", dataDir))
+  {
+    _path = ignition::common::joinPaths(dataDir,
+        "__main__/ign_plugin/test/IGNDummyPlugins.so");
+    return true;
+  }
+#endif
+  return false;
+}
 
 /////////////////////////////////////////////////
 TEST(Loader, InitialNoInterfacesImplemented)
@@ -43,15 +84,22 @@ TEST(Loader, LoadNonexistantLibrary)
 TEST(Loader, LoadNonLibrary)
 {
   ignition::plugin::Loader loader;
-  EXPECT_TRUE(loader.LoadLib(std::string(IGN_PLUGIN_SOURCE_DIR)
-                             + "/core/src/Plugin.cc").empty());
+
+  std::ofstream tmpOut("test.tmp");
+  tmpOut.close();
+
+  EXPECT_TRUE(loader.LoadLib("test.tmp").empty());
 }
 
 /////////////////////////////////////////////////
 TEST(Loader, LoadNonPluginLibrary)
 {
   ignition::plugin::Loader loader;
-  EXPECT_TRUE(loader.LoadLib(IGN_PLUGIN_LIB).empty());
+
+  std::string libPath;
+  ASSERT_TRUE(IgnPluginLib(libPath));
+
+  EXPECT_TRUE(loader.LoadLib(libPath).empty());
 }
 
 /////////////////////////////////////////////////
@@ -84,11 +132,14 @@ TEST(Loader, DoubleLoad)
   // when a user asks for a library to be loaded twice.
   ignition::plugin::Loader loader;
 
-  loader.LoadLib(IGNDummyPlugins_LIB);
+  std::string libPath;
+  ASSERT_TRUE(IgnDummyPluginLib(libPath));
+
+  loader.LoadLib(libPath);
   const std::size_t interfaceCount = loader.InterfacesImplemented().size();
   EXPECT_LT(0u, interfaceCount);
 
-  loader.LoadLib(IGNDummyPlugins_LIB);
+  loader.LoadLib(libPath);
   EXPECT_EQ(interfaceCount, loader.InterfacesImplemented().size());
 }
 
@@ -96,20 +147,22 @@ TEST(Loader, DoubleLoad)
 TEST(Loader, ForgetUnloadedLibrary)
 {
   // These tests are for line coverage.
+  std::string libPath;
+  ASSERT_TRUE(IgnDummyPluginLib(libPath));
 
   // This first test triggers lines for the case that:
   //   1. A library is not loaded, and
   //   2. We tell a loader to forget the library
   ignition::plugin::Loader loader;
-  EXPECT_FALSE(loader.ForgetLibrary(IGNDummyPlugins_LIB));
+  EXPECT_FALSE(loader.ForgetLibrary(libPath));
 
   // This next test triggers lines for the case that:
   //   1. A library is loaded by some loader in the application, and
   //   2. We tell a *different* loader to forget the library
   ignition::plugin::Loader hasTheLibrary;
-  EXPECT_LT(0u, hasTheLibrary.LoadLib(IGNDummyPlugins_LIB).size());
+  EXPECT_LT(0u, hasTheLibrary.LoadLib(libPath).size());
 
-  EXPECT_FALSE(loader.ForgetLibrary(IGNDummyPlugins_LIB));
+  EXPECT_FALSE(loader.ForgetLibrary(libPath));
 }
 
 /////////////////////////////////////////////////

--- a/register/BUILD.bazel
+++ b/register/BUILD.bazel
@@ -50,10 +50,10 @@ public_headers = public_headers_no_gen + [
 ]
 
 cc_binary(
-    name = "libign_plugin-register.so",
+    name = "libignition-plugin2-register.so",
     srcs = public_headers,
     includes = ["include"],
-    linkopts = ["-Wl,-soname,libign_plugin-register.so"],
+    linkopts = ["-Wl,-soname,libignition-plugin2-register.so"],
     linkshared = True,
     visibility = [],
     deps = [
@@ -64,11 +64,14 @@ cc_binary(
 
 cc_library(
     name = "register",
-    srcs = ["libign_plugin-register.so"],
+    srcs = ["libignition-plugin2-register.so"],
     hdrs = public_headers,
     includes = ["include"],
     visibility = ["//visibility:public"],
     linkstatic = True,
     alwayslink = 1,
-    deps = [],
+    deps = [
+        "//ign_plugin/core:ign_plugin",
+        "//ign_bazel:utilities",
+    ],
 )

--- a/register/BUILD.bazel
+++ b/register/BUILD.bazel
@@ -1,0 +1,74 @@
+load(
+    "//ign_bazel:generate_include_header.bzl",
+    "generate_include_header",
+)
+
+load(
+    "//ign_bazel:generate_file.bzl",
+    "generate_file",
+)
+
+public_headers_no_gen = [
+    "include/ignition/plugin/Register.hh",
+    "include/ignition/plugin/RegisterMore.hh",
+    "include/ignition/plugin/detail/Register.hh",
+]
+
+generate_file(
+    name = "include/ignition/plugin/register/Export.hh",
+    content = """
+#pragma once
+// IGN_DEPRECATED is defined by all ignition libraries, but the version below
+// is a simplified version.  When mixing the regular ignition libraries and
+// the drake compiled ignition libraries, the compiler throws a warning about
+// the macro being multiply defined.  We undefine it before redefining it here
+// to work around that issue.  Note that the IGNITION_PLUGIN_REGISTER_VISIBLE macro
+// shouldn't be defined multiple times, but we undefine it just in case.
+#ifdef IGNITION_PLUGIN_REGISTER_VISIBLE
+#undef IGNITION_PLUGIN_REGISTER_VISIBLE
+#endif
+#define IGNITION_PLUGIN_REGISTER_VISIBLE __attribute__ ((visibility("default")))
+#ifdef IGN_DEPRECATED
+#undef IGN_DEPRECATED
+#endif
+#define IGN_DEPRECATED(version) __attribute__ ((__deprecated__))
+    """,
+    visibility = ["//visibility:private"],
+)
+
+generate_include_header(
+    name = "register_hh_genrule",
+    out = "include/ignition/plugin/register.hh",
+    hdrs = public_headers_no_gen + [
+        "include/ignition/plugin/register/Export.hh",
+    ],
+)
+
+public_headers = public_headers_no_gen + [
+    "include/ignition/plugin/register/Export.hh",
+    "include/ignition/plugin/register.hh",
+]
+
+cc_binary(
+    name = "libign_plugin-register.so",
+    srcs = public_headers,
+    includes = ["include"],
+    linkopts = ["-Wl,-soname,libign_plugin-register.so"],
+    linkshared = True,
+    visibility = [],
+    deps = [
+        "//ign_plugin/core:ign_plugin",
+        "//ign_bazel:utilities",
+    ],
+)
+
+cc_library(
+    name = "register",
+    srcs = ["libign_plugin-register.so"],
+    hdrs = public_headers,
+    includes = ["include"],
+    visibility = ["//visibility:public"],
+    linkstatic = True,
+    alwayslink = 1,
+    deps = [],
+)

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -1,0 +1,63 @@
+plugin_sources = [
+    "plugins/BadPluginAlign.cc",
+    "plugins/BadPluginAPIVersionNew.cc",
+    "plugins/BadPluginAPIVersionOld.cc",
+    "plugins/BadPluginNoInfo.cc",
+    "plugins/BadPluginSize.cc",
+    "plugins/FactoryPlugins.cc",
+    "plugins/TemplatedPlugins.cc",
+]
+
+headers = [
+    "plugins/DummyPlugins.hh",
+    "plugins/DummyMultiPlugin.hh",
+    "plugins/FactoryPlugins.hh",
+    "plugins/GenericExport.hh",
+    "plugins/TemplatedPlugins.hh"
+]
+
+[
+    cc_binary(
+        name = 'IGN' + plugin.split('/')[1].replace('.cc', '') + '.so',
+        srcs = [plugin] + headers,
+        deps = ["//ign_plugin/register"],
+        includes = ["plugins"],
+        visibility = ["//visibility:public"],
+        linkshared = True,
+    )
+    for plugin in plugin_sources
+]
+
+cc_binary(
+    name = "IGNDummyPlugins.so",
+    srcs = [
+        "plugins/DummyPlugins.cc",
+        "plugins/DummyPluginsOtherTranslationUnit.cc",
+        "plugins/DummyPlugins.hh",
+        "plugins/DummyMultiPlugin.hh"
+    ],
+    deps = ["//ign_plugin/register"],
+    includes = ["plugins"],
+    visibility = ["//visibility:public"],
+    linkshared = True,
+)
+
+[
+    cc_test(
+        name = "INTEGRATION_" + test.split('/')[1].replace('.cc', ''),
+        srcs = [ test, "integration/utils.hh" ] + headers,
+        deps = [
+          "//ign_common",
+          "//ign_plugin/register",
+          "//ign_plugin/loader",
+          "@gtest//:gtest",
+          "@gtest//:gtest_main",
+          ":IGNDummyPlugins.so",
+          ":IGNFactoryPlugins.so",
+          ":IGNTemplatedPlugins.so",
+        ],
+        includes = [".", "plugins", "integration"],
+    ) for test in glob(["integration/*.cc"])
+]
+
+

--- a/test/integration/EnablePluginFromThis_TEST.cc
+++ b/test/integration/EnablePluginFromThis_TEST.cc
@@ -17,6 +17,9 @@
 
 #include <gtest/gtest.h>
 
+#include <ignition/common/Filesystem.hh>
+#include <ignition/common/Util.hh>
+
 #include <ignition/plugin/EnablePluginFromThis.hh>
 #include <ignition/plugin/Loader.hh>
 #include <ignition/plugin/SpecializedPluginPtr.hh>
@@ -26,10 +29,30 @@
 #include "utils.hh"
 
 /////////////////////////////////////////////////
+bool IgnDummyPluginLib(std::string &_path)
+{
+#ifdef IGNDummyPlugins_LIB
+  _path = IGNDummyPlugins_LIB;
+  return true;
+#else
+  std::string dataDir;
+  if (ignition::common::env("TEST_SRCDIR", dataDir))
+  {
+    _path = ignition::common::joinPaths(dataDir,
+        "__main__/ign_plugin/test/IGNDummyPlugins.so");
+    return true;
+  }
+#endif
+  return false;
+}
+
+/////////////////////////////////////////////////
 TEST(EnablePluginFromThis, BasicInstantiate)
 {
   ignition::plugin::Loader pl;
-  pl.LoadLib(IGNDummyPlugins_LIB);
+  std::string libPath;
+  ASSERT_TRUE(IgnDummyPluginLib(libPath));
+  pl.LoadLib(libPath);
 
   ignition::plugin::PluginPtr plugin =
       pl.Instantiate("test::util::DummyMultiPlugin");
@@ -74,7 +97,9 @@ using MySpecializedPluginPtr = ignition::plugin::SpecializedPluginPtr<
 TEST(EnablePluginFromThis, TemplatedInstantiate)
 {
   ignition::plugin::Loader pl;
-  pl.LoadLib(IGNDummyPlugins_LIB);
+  std::string libPath;
+  ASSERT_TRUE(IgnDummyPluginLib(libPath));
+  pl.LoadLib(libPath);
 
   MySpecializedPluginPtr plugin =
       pl.Instantiate<MySpecializedPluginPtr>("test::util::DummyMultiPlugin");
@@ -101,7 +126,9 @@ TEST(EnablePluginFromThis, TemplatedInstantiate)
 /////////////////////////////////////////////////
 TEST(EnablePluginFromThis, LibraryManagement)
 {
-  const std::string &libraryPath = IGNDummyPlugins_LIB;
+  std::string libPath;
+  ASSERT_TRUE(IgnDummyPluginLib(libPath));
+  const std::string &libraryPath = libPath;
 
   ignition::plugin::WeakPluginPtr weak;
 

--- a/test/integration/aliases.cc
+++ b/test/integration/aliases.cc
@@ -17,18 +17,42 @@
 
 #include <gtest/gtest.h>
 
+#include <ignition/common/Filesystem.hh>
+#include <ignition/common/Util.hh>
+
 #include <ignition/plugin/Loader.hh>
 
 #include "../plugins/DummyPlugins.hh"
+
+/////////////////////////////////////////////////
+bool IgnDummyPluginLib(std::string &_path)
+{
+#ifdef IGNDummyPlugins_LIB
+  _path = IGNDummyPlugins_LIB;
+  return true;
+#else
+  std::string dataDir;
+  if (ignition::common::env("TEST_SRCDIR", dataDir))
+  {
+    _path = ignition::common::joinPaths(dataDir,
+        "__main__/ign_plugin/test/IGNDummyPlugins.so");
+    return true;
+  }
+#endif
+  return false;
+}
 
 /////////////////////////////////////////////////
 TEST(Alias, InspectAliases)
 {
   ignition::plugin::Loader pl;
 
+  std::string libPath;
+  ASSERT_TRUE(IgnDummyPluginLib(libPath));
+
   // Make sure the expected plugins were loaded.
   std::unordered_set<std::string> pluginNames =
-      pl.LoadLib(IGNDummyPlugins_LIB);
+      pl.LoadLib(libPath);
   ASSERT_EQ(1u, pluginNames.count("test::util::DummySinglePlugin"));
   ASSERT_EQ(1u, pluginNames.count("test::util::DummyMultiPlugin"));
   ASSERT_EQ(1u, pluginNames.count("test::util::DummyNoAliasPlugin"));
@@ -51,9 +75,12 @@ TEST(Alias, ConflictingAlias)
 {
   ignition::plugin::Loader pl;
 
+  std::string libPath;
+  ASSERT_TRUE(IgnDummyPluginLib(libPath));
+
   // Make sure the expected plugins were loaded.
   std::unordered_set<std::string> pluginNames =
-      pl.LoadLib(IGNDummyPlugins_LIB);
+      pl.LoadLib(libPath);
   ASSERT_EQ(1u, pluginNames.count("test::util::DummySinglePlugin"));
   ASSERT_EQ(1u, pluginNames.count("test::util::DummyMultiPlugin"));
   ASSERT_EQ(1u, pluginNames.count("test::util::DummyNoAliasPlugin"));

--- a/test/integration/plugin.cc
+++ b/test/integration/plugin.cc
@@ -24,6 +24,10 @@
 #include <string>
 #include <vector>
 #include <iostream>
+
+#include <ignition/common/Filesystem.hh>
+#include <ignition/common/Util.hh>
+
 #include "ignition/plugin/Loader.hh"
 #include "ignition/plugin/PluginPtr.hh"
 #include "ignition/plugin/SpecializedPluginPtr.hh"
@@ -32,14 +36,62 @@
 #include "utils.hh"
 
 /////////////////////////////////////////////////
-TEST(Loader, LoadBadPlugins)
+bool BadPlugins(std::vector<std::string> &_paths)
 {
-  std::vector<std::string> libraries = {
+#ifdef IGNDummyPlugins_LIB
+  _paths = std::vector<std::string>{
     IGNBadPluginAPIVersionOld_LIB,
     IGNBadPluginAPIVersionNew_LIB,
     IGNBadPluginAlign_LIB,
     IGNBadPluginNoInfo_LIB,
     IGNBadPluginSize_LIB};
+  return true;
+#else
+  std::string dataDir;
+  if (ignition::common::env("TEST_SRCDIR", dataDir))
+  {
+    _paths = std::vector<std::string>{
+      ignition::common::joinPaths(dataDir,
+          "__main__/ign_plugin/test/IGNBadPluginAPIVersionOld.so"),
+      ignition::common::joinPaths(dataDir,
+          "__main__/ign_plugin/test/IGNBadPluginAPIVersionNew.so"),
+      ignition::common::joinPaths(dataDir,
+          "__main__/ign_plugin/test/IGNBadPluginAlign.so"),
+      ignition::common::joinPaths(dataDir,
+          "__main__/ign_plugin/test/IGNBadPluginNoInfo.so"),
+      ignition::common::joinPaths(dataDir,
+          "__main__/ign_plugin/test/IGNBadPluginSize.so")
+    };
+    return true;
+  }
+#endif
+  return false;
+
+}
+
+/////////////////////////////////////////////////
+bool IgnDummyPluginLib(std::string &_path)
+{
+#ifdef IGNDummyPlugins_LIB
+  _path = IGNDummyPlugins_LIB;
+  return true;
+#else
+  std::string dataDir;
+  if (ignition::common::env("TEST_SRCDIR", dataDir))
+  {
+    _path = ignition::common::joinPaths(dataDir,
+        "__main__/ign_plugin/test/IGNDummyPlugins.so");
+    return true;
+  }
+#endif
+  return false;
+}
+
+/////////////////////////////////////////////////
+TEST(Loader, LoadBadPlugins)
+{
+  std::vector<std::string> libraries;
+  ASSERT_TRUE(BadPlugins(libraries));
   for (auto const & library : libraries)
   {
     ignition::plugin::Loader pl;
@@ -54,10 +106,11 @@ TEST(Loader, LoadBadPlugins)
 TEST(Loader, LoadExistingLibrary)
 {
   ignition::plugin::Loader pl;
+  std::string libPath;
+  ASSERT_TRUE(IgnDummyPluginLib(libPath));
 
   // Make sure the expected plugins were loaded.
-  std::unordered_set<std::string> pluginNames =
-      pl.LoadLib(IGNDummyPlugins_LIB);
+  std::unordered_set<std::string> pluginNames = pl.LoadLib(libPath);
   ASSERT_EQ(1u, pluginNames.count("test::util::DummySinglePlugin"));
   ASSERT_EQ(1u, pluginNames.count("test::util::DummyMultiPlugin"));
 
@@ -160,7 +213,9 @@ using SomeSpecializedPluginPtr =
 TEST(SpecializedPluginPtr, Construction)
 {
   ignition::plugin::Loader pl;
-  pl.LoadLib(IGNDummyPlugins_LIB);
+  std::string libPath;
+  ASSERT_TRUE(IgnDummyPluginLib(libPath));
+  pl.LoadLib(libPath);
 
   SomeSpecializedPluginPtr plugin(
         pl.Instantiate("test::util::DummyMultiPlugin"));
@@ -302,7 +357,9 @@ TEST(PluginPtr, CopyMoveSemantics)
   EXPECT_TRUE(plugin.IsEmpty());
 
   ignition::plugin::Loader pl;
-  pl.LoadLib(IGNDummyPlugins_LIB);
+  std::string libPath;
+  ASSERT_TRUE(IgnDummyPluginLib(libPath));
+  pl.LoadLib(libPath);
 
   plugin = pl.Instantiate("test::util::DummySinglePlugin");
   EXPECT_FALSE(plugin.IsEmpty());
@@ -383,7 +440,9 @@ void CheckSomeValues(
 TEST(PluginPtr, QueryInterfaceSharedPtr)
 {
   ignition::plugin::Loader pl;
-  pl.LoadLib(IGNDummyPlugins_LIB);
+  std::string libPath;
+  ASSERT_TRUE(IgnDummyPluginLib(libPath));
+  pl.LoadLib(libPath);
 
   // QueryInterfaceSharedPtr without specialization
   {
@@ -464,7 +523,9 @@ ignition::plugin::PluginPtr GetSomePlugin(const std::string &path)
 /////////////////////////////////////////////////
 TEST(PluginPtr, LibraryManagement)
 {
-  const std::string &path = IGNDummyPlugins_LIB;
+  std::string libPath;
+  ASSERT_TRUE(IgnDummyPluginLib(libPath));
+  const std::string &path = libPath;
 
   // Use scoping to destroy somePlugin
   {

--- a/test/integration/templated_plugins.cc
+++ b/test/integration/templated_plugins.cc
@@ -22,6 +22,9 @@
 
 #include <gtest/gtest.h>
 
+#include <ignition/common/Filesystem.hh>
+#include <ignition/common/Util.hh>
+
 #include <ignition/plugin/Loader.hh>
 #include <ignition/plugin/SpecializedPluginPtr.hh>
 
@@ -30,10 +33,30 @@
 using namespace test::plugins;
 
 /////////////////////////////////////////////////
+bool IgnTemplatedPluginLib(std::string &_path)
+{
+#ifdef IGNTemplatedPlugins_LIB
+  _path = IGNTemplatedPlugins_LIB;
+  return true;
+#else
+  std::string dataDir;
+  if (ignition::common::env("TEST_SRCDIR", dataDir))
+  {
+    _path = ignition::common::joinPaths(dataDir,
+        "__main__/ign_plugin/test/IGNTemplatedPlugins.so");
+    return true;
+  }
+#endif
+  return false;
+}
+
+/////////////////////////////////////////////////
 TEST(TemplatedPlugins, InterfaceCount)
 {
   ignition::plugin::Loader pl;
-  pl.LoadLib(IGNTemplatedPlugins_LIB);
+  std::string libPath;
+  ASSERT_TRUE(IgnTemplatedPluginLib(libPath));
+  pl.LoadLib(libPath);
 
   const std::size_t getIntCount =
        pl.PluginsImplementing< TemplatedGetInterface<int> >().size();
@@ -105,7 +128,9 @@ void TestSetAndGet(const ignition::plugin::Loader &_pl,
 TEST(TemplatedPlugins, SetAndGet)
 {
   ignition::plugin::Loader pl;
-  pl.LoadLib(IGNTemplatedPlugins_LIB);
+  std::string libPath;
+  ASSERT_TRUE(IgnTemplatedPluginLib(libPath));
+  pl.LoadLib(libPath);
 
   TestSetAndGet<int>(pl, 120);
   TestSetAndGet<std::string>(pl, "some amazing string");


### PR DESCRIPTION
We'll need to set these paths for the loader test to work: IGN_PLUGIN_SOURCE_DIR, IGN_PLUGIN_LIB, IGNDummyPlugins_LIB.  Other than that, all tests are passing.

Additionally, should we move the core build file a directory above to keep consistent with the other packages?  Ie, you can include `ign_math` with `//ign_math:ign_math` but for `ign_plugin` you have to use `//ign_plugin/core:ign_plugin`

Signed-off-by: John Shepherd <john@openrobotics.org>