### PR TITLE
Removed repeated installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ of libraries designed to rapidly develop robot applications.
 
 ## Installation
 
-Review the [tutorial section](https://ignitionrobotics.org/api/plugin/1.1/installation.html).
+See the [installation tutorial](https://ignitionrobotics.org/api/plugin/1.1/installation.html).
 
 ## Test
 

--- a/README.md
+++ b/README.md
@@ -23,20 +23,7 @@ of libraries designed to rapidly develop robot applications.
 
 ## Installation
 
-Standard installation can be performed in UNIX systems using the following
-steps:
-
-    mkdir build/
-    cd build/
-    cmake ..
-    sudo make install
-
-## Uninstallation
-
-To uninstall the software installed with the previous steps:
-
-    cd build/
-    sudo make uninstall
+Review the [tutorial section](tutorials/02_installation.md).
 
 ## Test
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ of libraries designed to rapidly develop robot applications.
 
 ## Installation
 
-Review the [tutorial section](tutorials/02_installation.md).
+Review the [tutorial section](https://ignitionrobotics.org/api/plugin/1.1/installation.html).
 
 ## Test
 


### PR DESCRIPTION
This PR is related with this issue https://github.com/ignitionrobotics/docs/issues/14

Moved install instructions to the tutorials folder.

Signed-off-by: ahcorde <ahcorde@gmail.com>