### PR TITLE
Load global symbols

### DIFF
--- a/loader/src/Loader.cc
+++ b/loader/src/Loader.cc
@@ -452,7 +452,8 @@ namespace ignition
       // state gets cleared each time it is called.
       dlerror();
 
-      // NOTE: We are using RTLD_GLOBAL, this may overwrite the symbols of different libraries.
+      // NOTE: We are using RTLD_GLOBAL, this may overwrite the symbols of
+      // different libraries.
       void * dlHandle = dlopen(_full_path.c_str(), RTLD_LAZY | RTLD_GLOBAL);
 
       const char *loadError = dlerror();

--- a/loader/src/Loader.cc
+++ b/loader/src/Loader.cc
@@ -368,7 +368,7 @@ namespace ignition
 #endif
 
       void *dlHandle = dlopen(_pathToLibrary.c_str(),
-                              RTLD_NOLOAD | RTLD_LAZY | RTLD_LOCAL);
+                              RTLD_NOLOAD | RTLD_LAZY | RTLD_GLOBAL);
 
       if (!dlHandle)
         return false;
@@ -454,7 +454,9 @@ namespace ignition
 
       // NOTE: We are using RTLD_GLOBAL, this may overwrite the symbols of
       // different libraries.
-      void * dlHandle = dlopen(_full_path.c_str(), RTLD_LAZY | RTLD_GLOBAL);
+      void * dlHandle = dlopen(
+          _full_path.c_str(),
+          RTLD_LAZY | RTLD_GLOBAL | RTLD_NODELETE);
 
       const char *loadError = dlerror();
       if (nullptr == dlHandle || nullptr != loadError)
@@ -632,7 +634,9 @@ namespace ignition
 
       if (loadedPlugins.size() == 0)
       {
-        return LoadPlugins(nullptr, _pathToLibrary);
+        if (_dlHandle != nullptr) {
+          return LoadPlugins(nullptr, _pathToLibrary);
+        }
       }
 
       return loadedPlugins;

--- a/loader/src/Loader.cc
+++ b/loader/src/Loader.cc
@@ -452,6 +452,13 @@ namespace ignition
       // state gets cleared each time it is called.
       dlerror();
 
+#ifndef RTLD_NODELETE
+// This macro is not part of the POSIX standard, and is a custom addition to
+// glibc-2.2, so we need create a no-op stand-in flag for it if we are not
+// using glibc-2.2.
+#define RTLD_NODELETE 0
+#endif
+
       // NOTE: We are using RTLD_GLOBAL, this may overwrite the symbols of
       // different libraries.
       void * dlHandle = dlopen(

--- a/loader/src/Loader.cc
+++ b/loader/src/Loader.cc
@@ -452,9 +452,8 @@ namespace ignition
       // state gets cleared each time it is called.
       dlerror();
 
-      // NOTE: We open using RTLD_LOCAL instead of RTLD_GLOBAL to prevent the
-      // symbols of different libraries from writing over each other.
-      void *dlHandle = dlopen(_full_path.c_str(), RTLD_LAZY | RTLD_LOCAL);
+      // NOTE: We are using RTLD_GLOBAL, this may overwrite the symbols of different libraries.
+      void * dlHandle = dlopen(_full_path.c_str(), RTLD_LAZY | RTLD_GLOBAL);
 
       const char *loadError = dlerror();
       if (nullptr == dlHandle || nullptr != loadError)
@@ -536,12 +535,6 @@ namespace ignition
         const std::string& _pathToLibrary) const
     {
       std::vector<Info> loadedPlugins;
-
-      // This function should never be called with a nullptr _dlHandle
-      assert(_dlHandle &&
-             "Bug in code: Loader::Implementation::LoadPlugins was called with "
-             "a nullptr value for _dlHandle.");
-
       const std::string infoSymbol = "IgnitionPluginHook";
       void *infoFuncPtr = dlsym(_dlHandle.get(), infoSymbol.c_str());
 
@@ -634,6 +627,11 @@ namespace ignition
       for (const InfoMap::value_type &info : *allInfo)
       {
         loadedPlugins.push_back(info.second);
+      }
+
+      if (loadedPlugins.size() == 0)
+      {
+        return LoadPlugins(nullptr, _pathToLibrary);
       }
 
       return loadedPlugins;

--- a/test/integration/EnablePluginFromThis_TEST.cc
+++ b/test/integration/EnablePluginFromThis_TEST.cc
@@ -108,8 +108,6 @@ TEST(EnablePluginFromThis, LibraryManagement)
   {
     ignition::plugin::PluginPtr longterm;
 
-    CHECK_FOR_LIBRARY(libraryPath, false);
-
     {
       ignition::plugin::Loader pl;
       pl.LoadLib(libraryPath);
@@ -136,8 +134,6 @@ TEST(EnablePluginFromThis, LibraryManagement)
   }
 
   EXPECT_TRUE(weak.IsExpired());
-
-  CHECK_FOR_LIBRARY(libraryPath, false);
 }
 
 /////////////////////////////////////////////////

--- a/test/integration/WeakPluginPtr.cc
+++ b/test/integration/WeakPluginPtr.cc
@@ -56,8 +56,6 @@ TEST(WeakPluginPtr, Lifecycle)
     CHECK_FOR_LIBRARY(libraryPath, true);
   }
 
-  CHECK_FOR_LIBRARY(libraryPath, false);
-
   EXPECT_TRUE(weak.IsExpired());
 
   ignition::plugin::PluginPtr empty = weak.Lock();

--- a/test/integration/factory.cc
+++ b/test/integration/factory.cc
@@ -164,8 +164,6 @@ TEST(Factory, LibraryManagement)
     CHECK_FOR_LIBRARY(libraryPath, true);
   }
 
-  CHECK_FOR_LIBRARY(libraryPath, false);
-
   // Test that we can release from a ProductPtr, and the library will still
   // remain loaded, and then it will unload correctly later, as long as we
   // manually destruct with a ProductDeleter
@@ -192,11 +190,7 @@ TEST(Factory, LibraryManagement)
     CHECK_FOR_LIBRARY(libraryPath, true);
 
     ignition::plugin::ProductDeleter<SomeObject>()(obj);
-
-    CHECK_FOR_LIBRARY(libraryPath, false);
   }
-
-  CHECK_FOR_LIBRARY(libraryPath, false);
 
   // Test that if we release from a ProductPtr but do not delete it with a
   // ProductDeleter, then its shared library will remain loaded until we call
@@ -238,9 +232,6 @@ TEST(Factory, LibraryManagement)
 
   // Now there should be no more lost products, so this count is 0.
   EXPECT_EQ(0u, ignition::plugin::LostProductCount());
-
-  // With the reference counts deleted, the library should automatically unload.
-  CHECK_FOR_LIBRARY(libraryPath, false);
 }
 
 /////////////////////////////////////////////////

--- a/test/integration/plugin.cc
+++ b/test/integration/plugin.cc
@@ -31,26 +31,7 @@
 #include "../plugins/DummyPlugins.hh"
 #include "utils.hh"
 
-/////////////////////////////////////////////////
-TEST(Loader, LoadBadPlugins)
-{
-  std::vector<std::string> libraries = {
-    IGNBadPluginAPIVersionOld_LIB,
-    IGNBadPluginAPIVersionNew_LIB,
-    IGNBadPluginAlign_LIB,
-    IGNBadPluginNoInfo_LIB,
-    IGNBadPluginSize_LIB};
-  for (auto const & library : libraries)
-  {
-    ignition::plugin::Loader pl;
-
-    // Make sure the expected plugins were loaded.
-    std::unordered_set<std::string> pluginNames = pl.LoadLib(library);
-    EXPECT_TRUE(pluginNames.empty());
-  }
-}
-
-/////////////////////////////////////////////////
+////////////////////////////////////////////////
 TEST(Loader, LoadExistingLibrary)
 {
   ignition::plugin::Loader pl;
@@ -145,7 +126,6 @@ TEST(Loader, LoadExistingLibrary)
                 ->MyIntegerValueIs(), object.dummyInt);
   EXPECT_NEAR(doubleBase->MyDoubleValueIs(), object.dummyDouble, 1e-8);
 }
-
 
 /////////////////////////////////////////////////
 class SomeInterface { };
@@ -474,12 +454,9 @@ TEST(PluginPtr, LibraryManagement)
     CHECK_FOR_LIBRARY(path, true);
   }
 
-  CHECK_FOR_LIBRARY(path, false);
-
   // Test that we can transfer between plugins
   {
     ignition::plugin::PluginPtr somePlugin;
-    CHECK_FOR_LIBRARY(path, false);
 
     {
       ignition::plugin::PluginPtr temporaryPlugin = GetSomePlugin(path);
@@ -490,8 +467,6 @@ TEST(PluginPtr, LibraryManagement)
     CHECK_FOR_LIBRARY(path, true);
   }
 
-  CHECK_FOR_LIBRARY(path, false);
-
   // Test that we can forget libraries
   {
     ignition::plugin::Loader pl;
@@ -500,8 +475,6 @@ TEST(PluginPtr, LibraryManagement)
     CHECK_FOR_LIBRARY(path, true);
 
     EXPECT_TRUE(pl.ForgetLibrary(path));
-
-    CHECK_FOR_LIBRARY(path, false);
   }
 
   // Test that we can forget libraries, but the library will remain loaded if
@@ -523,8 +496,6 @@ TEST(PluginPtr, LibraryManagement)
   }
 
   // Check that the library will be unloaded once the plugin instance is deleted
-  CHECK_FOR_LIBRARY(path, false);
-
   // Check that we can unload libraries based on plugin name
   {
     ignition::plugin::Loader pl;
@@ -533,8 +504,6 @@ TEST(PluginPtr, LibraryManagement)
     CHECK_FOR_LIBRARY(path, true);
 
     pl.ForgetLibraryOfPlugin("test::util::DummyMultiPlugin");
-
-    CHECK_FOR_LIBRARY(path, false);
   }
 
   // Check that the std::shared_ptrs that we provide for interfaces will
@@ -542,7 +511,6 @@ TEST(PluginPtr, LibraryManagement)
   {
     std::shared_ptr<test::util::DummyNameBase> interface;
 
-    CHECK_FOR_LIBRARY(path, false);
     {
       interface = GetSomePlugin(path)->QueryInterfaceSharedPtr<
           test::util::DummyNameBase>();
@@ -555,8 +523,6 @@ TEST(PluginPtr, LibraryManagement)
 
     CHECK_FOR_LIBRARY(path, true);
   }
-
-  CHECK_FOR_LIBRARY(path, false);
 
   // Check that mulitple Loaders can work side-by-side
   {
@@ -574,8 +540,25 @@ TEST(PluginPtr, LibraryManagement)
 
     CHECK_FOR_LIBRARY(path, true);
   }
+}
 
-  CHECK_FOR_LIBRARY(path, false);
+/////////////////////////////////////////////////
+TEST(Loader, LoadBadPlugins)
+{
+  std::vector<std::string> libraries = {
+    IGNBadPluginAPIVersionOld_LIB,
+    IGNBadPluginAPIVersionNew_LIB,
+    IGNBadPluginAlign_LIB,
+    IGNBadPluginNoInfo_LIB,
+    IGNBadPluginSize_LIB};
+  for (auto const & library : libraries)
+  {
+    ignition::plugin::Loader pl;
+
+    // Make sure the expected plugins were loaded.
+    std::unordered_set<std::string> pluginNames = pl.LoadLib(library);
+    EXPECT_TRUE(pluginNames.empty());
+  }
 }
 
 /////////////////////////////////////////////////


### PR DESCRIPTION
This is the basic PR to make use of `ign-plugin` in other libraries.

This comment in this other PR https://github.com/ignitionrobotics/ign-sensors/pull/38#issuecomment-678123125 explains what is going on. Basically some libraries pre-load some symbols of other libraries (for example `libignition-gazebo4-sensors-system.so` pre-load some ign-sensor symbols) and when you need to load some of the ign-sensor libraries you can't access these symbols because it was load previously.

Using `RTLD_GLOBAL` we can access theses symbols but we should filter in all the libraries and look for the right one.

Signed-off-by: ahcorde <ahcorde@gmail.com>