### PR TITLE
Disable more ign tool functionality on windows

### DIFF
--- a/loader/CMakeLists.txt
+++ b/loader/CMakeLists.txt
@@ -57,5 +57,7 @@ install(
 #============================================================================
 # ign command line support
 #============================================================================
-add_subdirectory(conf)
-add_subdirectory(src)
+if(NOT MSVC)
+  add_subdirectory(conf)
+  add_subdirectory(src)
+endif()


### PR DESCRIPTION
This is needed to fix downstream colcon builds on windows.