### PR TITLE
Fix downstream Windows builds

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -77,7 +77,7 @@ you choose exactly one.
 
 # Loading a library
 
-The `ignition::common::SystemPaths` class was not ported into `ign-plugin` 
+The `ignition::common::SystemPaths` class was not ported into `ign-plugin`
 because it is more related to filesystem utilities than to plugins. If you are
 currently using `ignition::common::SystemPaths` to help with loading plugins,
 then you should continue to use it. It does not have a replacement in `ign-plugin`.

--- a/loader/src/CMakeLists.txt
+++ b/loader/src/CMakeLists.txt
@@ -1,2 +1,4 @@
 # Command line support.
-add_subdirectory(cmd)
+if(NOT WIN32)
+  add_subdirectory(cmd)
+endif()


### PR DESCRIPTION
Signed-off-by: Louise Poubel <louise@openrobotics.org>

<!-- Please remove the appropriate section.
For example, if this is a new feature, remove the "Bug Report" section -->

# Bug Fix

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

Downstream builds have been broken since #32  with:

```
CMake Error in loader/src/cmd/CMakeLists.txt:
  Evaluation file to be written multiple times with different content.  This
  is generally caused by the content evaluating the configuration type,
  language, or location of object files:

   D:/Jenkins/workspace/ign_gazebo-ci-win/ws/build/ignition-plugin1/test/lib/ruby/ignition/cmdplugin1.rb


CMake Error in loader/src/cmd/CMakeLists.txt:
  Evaluation file to be written multiple times with different content.  This
  is generally caused by the content evaluating the configuration type,
  language, or location of object files:

   D:/Jenkins/workspace/ign_gazebo-ci-win/ws/build/ignition-plugin1/test/lib/ruby/ignition/cmdplugin1.rb
```

I noticed this library is following SDFormat's example, and command line tools are [disabled on Windows there](https://github.com/osrf/sdformat/blob/5d08472ba3d2c30dcfe4c8876677e8ce935dfa5d/src/CMakeLists.txt#L226-L228), so I'm doing the same here to fix the build.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See
  [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See
  [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review
[another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+archived%3Afalse+)
to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**


