### PR TITLE
Remove ign-tools from CMakeLists.txt. Not used

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,11 +37,6 @@ ign_find_package(DL
   PRETTY libdl PURPOSE "Required for loading plugins")
 
 
-#--------------------------------------
-# Find ignition-tools
-ign_find_package(ignition-tools QUIET)
-
-
 #============================================================================
 # Configure the build
 #============================================================================


### PR DESCRIPTION
# 🦟 Bug fix


## Summary

Code is looking for ign-tools while I can not find any place where it is used.

## Checklist

**Note to maintainers**: Remember to use **Squash-Merge**
