### PR TITLE
Find ign program instead of ignition-tools

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,11 @@ ign_find_package(DL
   PRETTY libdl PURPOSE "Required for loading plugins")
 
 
+#--------------------------------------
+# Find ignition-tools
+find_program(IGN_TOOLS_PROGRAM ign)
+
+
 #============================================================================
 # Configure the build
 #============================================================================

--- a/loader/CMakeLists.txt
+++ b/loader/CMakeLists.txt
@@ -4,7 +4,7 @@
 ign_get_libsources_and_unittests(sources tests)
 
 # Disable ign_TEST if ignition-tools is not found
-if (MSVC OR NOT IGNITION-TOOLS_BINARY_DIRS)
+if (MSVC OR NOT IGN_TOOLS_PROGRAM)
   list(REMOVE_ITEM tests src/ign_TEST.cc)
 endif()
 
@@ -35,7 +35,7 @@ foreach(test ${test_targets})
     "IGNDummyPlugins_LIB=\"$<TARGET_FILE:IGNDummyPlugins>\"")
 
   target_compile_definitions(${test} PRIVATE
-    "IGN_PATH=\"${IGNITION-TOOLS_BINARY_DIRS}\"")
+    "IGN_PATH=\"${IGN_TOOLS_PROGRAM}\"")
 
   target_compile_definitions(${test} PRIVATE
     "IGN_VERSION_FULL=\"${PROJECT_VERSION_FULL}\"")

--- a/loader/src/ign_TEST.cc
+++ b/loader/src/ign_TEST.cc
@@ -58,7 +58,7 @@ std::string custom_exec_str(std::string _cmd)
 TEST(ignTest, PluginInfoNonexistentLibrary)
 {
   // Path to ign executable
-  std::string ign = std::string(IGN_PATH) + "/ign";
+  std::string ign = std::string(IGN_PATH);
 
   std::string output = custom_exec_str(ign + " plugin --info --plugin " +
       "/path/to/libDoesNotExist.so");
@@ -76,7 +76,7 @@ TEST(ignTest, PluginInfoNonexistentLibrary)
 TEST(ignTest, PluginInfoNonLibrary)
 {
   // Path to ign executable
-  std::string ign = std::string(IGN_PATH) + "/ign";
+  std::string ign = std::string(IGN_PATH);
 
   std::string output = custom_exec_str(ign + " plugin --info --plugin " +
       std::string(IGN_PLUGIN_SOURCE_DIR) + "/core/src/Plugin.cc");
@@ -94,7 +94,7 @@ TEST(ignTest, PluginInfoNonLibrary)
 TEST(ignTest, PluginInfoNonPluginLibrary)
 {
   // Path to ign executable
-  std::string ign = std::string(IGN_PATH) + "/ign";
+  std::string ign = std::string(IGN_PATH);
 
   std::string output = custom_exec_str(ign + " plugin --info --plugin " +
       IGN_PLUGIN_LIB);
@@ -113,7 +113,7 @@ TEST(ignTest, PluginInfoNonPluginLibrary)
 TEST(ignTest, PluginInfoDummyPlugins)
 {
   // Path to ign executable
-  std::string ign = std::string(IGN_PATH) + "/ign";
+  std::string ign = std::string(IGN_PATH);
 
   std::string output = custom_exec_str(ign + " plugin --info --plugin " +
       IGNDummyPlugins_LIB);
@@ -152,7 +152,7 @@ TEST(ignTest, PluginInfoDummyPlugins)
 TEST(ignTest, PluginInfoVerboseDummyPlugins)
 {
   // Path to ign executable
-  std::string ign = std::string(IGN_PATH) + "/ign";
+  std::string ign = std::string(IGN_PATH);
 
   std::string output = custom_exec_str(ign + " plugin --info --plugin " +
       IGNDummyPlugins_LIB + " --verbose");


### PR DESCRIPTION
# 🦟 Bug fix

Re-enable `UNIT_ign_TEST`

## Summary

The `find_package(ignition-tools)` call was removed in #56, but this disabled `UNIT_ign_TEST`. Instead, search for the `ign` program directly with `find_program` and adjust test logic accordingly.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [X] Updated documentation (as needed)
- [X] Updated migration guide (as needed)
- [X] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
