### PR TITLE
Testing labeler, please ignore

### DIFF
--- a/.github/workflows/pr-collection-labeler.yml
+++ b/.github/workflows/pr-collection-labeler.yml
@@ -1,13 +1,12 @@
 name: PR Collection Labeler
 
-on: pull_request_target
+on: pull_request_target, push
 
 jobs:
   pr_collection_labeler:
     runs-on: ubuntu-latest
     steps:
     - name: Add collection labels
-      if: github.event.action == 'opened'
-      uses: ignition-tooling/pr-collection-labeler@v1
+      uses: ignition-tooling/pr-collection-labeler@chapulina/debug_eol
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Ignition Plugin
+lala# Ignition Plugin
 
 **Maintainer:** grey [AT] openrobotics [DOT] org
 


### PR DESCRIPTION
* Testing https://github.com/ignition-tooling/pr-collection-labeler/pull/20

This PR shouldn't be labeled EOL even though `ign-plugin1` was used by Acropolis, Blueprint and Dome.