### PR TITLE
Relocate cli tool into libexec

### DIFF
--- a/loader/src/cmd/CMakeLists.txt
+++ b/loader/src/cmd/CMakeLists.txt
@@ -12,7 +12,7 @@ target_link_libraries(${plugin_executable}
   ${loader}
 )
 
-set(EXE_INSTALL_DIR "${IGN_LIB_INSTALL_DIR}/ignition/${IGN_DESIGNATION}${PROJECT_VERSION_MAJOR}")
+set(EXE_INSTALL_DIR "${CMAKE_INSTALL_LIBEXECDIR}/ignition/${IGN_DESIGNATION}${PROJECT_VERSION_MAJOR}")
 
 install(
   TARGETS


### PR DESCRIPTION
## Summary

CLI tool should be placed into libexec instead of using the standard location for libraries.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.