### PR TITLE
Bash completion for flags

### DIFF
--- a/plugin.bash_completion.sh
+++ b/plugin.bash_completion.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+# bash tab-completion
+
+# This is a per-library function definition, used in conjunction with the
+# top-level entry point in ign-tools.
+
+function _ign_plugin
+{
+  if [[ ${COMP_WORDS[COMP_CWORD]} == -* ]]; then
+    # Specify options (-*) word list for this subcommand
+    COMPREPLY=($(compgen -W "
+      -h --help
+      --help-all
+      --version
+      -v --verbose
+      -i --info
+      -p --plugin
+      " -- "${COMP_WORDS[COMP_CWORD]}" ))
+    return
+  else
+    # Just use bash default auto-complete, because we never have two
+    # subcommands in the same line. If that is ever needed, change here to
+    # detect subsequent subcommands
+    COMPREPLY=($(compgen -o default -- "${COMP_WORDS[COMP_CWORD]}"))
+    return
+  fi
+}


### PR DESCRIPTION
# 🎉 New feature

Part of https://github.com/ignitionrobotics/ign-tools/issues/1

## Summary

Bash completion script for flags available to this subcommand.
This is a standalone function that depends on a new script in ign-tools to call this.

## Test it

After sourcing the dependent script in ign-tools, source the script in this PR:
```
. plugin.bash_completion.sh
```

If you just tab, you get the default system tab-completion that shows the files in the current directory:
```
$ ign plugin <tab>
```

If you type `-`, and then tab, you get the tab-completion for all the flags available for this subcommand:
```
$ ign plugin -<tab>
--help      --help-all  --info      --plugin    --verbose   --version   -h          -i          -p          -v          
```

Then you can type partial flags, and it'll do tab-completion normally for you, such as
```
$ ign plugin --help<tab>
--help      --help-all  
```

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.