### PR TITLE
[bazel/infra] CI updates

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -1,9 +1,10 @@
 name: Bazel CI
 on:
-  push:
-    branches: [gz-plugin4, main]
   pull_request:
-    branches: [gz-plugin4, main]
+  push:
+    branches:
+      - 'gz-plugin[1-9]?[0-9]'
+      - 'main'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -11,7 +12,7 @@ concurrency:
 
 jobs:
   test:
-    uses: bazel-contrib/.github/.github/workflows/bazel.yaml@v7
+    uses: bazel-contrib/.github/.github/workflows/bazel.yaml@v7.2.3
     with:
       folders: |
         [


### PR DESCRIPTION
# Internal tooling

- Update branch filtering to always run on pull requests and conditionally on `main` and `gz-plugin[1-9]?[0-9]` (same as cmake CI).
- Update CI to use latest version of upstream bazel.yaml action to use released version of bazel (8) for tests

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.