### PR TITLE
Use rotary alias packages for CI

### DIFF
--- a/.github/ci/packages.apt
+++ b/.github/ci/packages.apt
@@ -1,3 +1,3 @@
-libgz-cmake5-dev
-libgz-tools2-dev
-libgz-utils4-cli-dev
+libgz-rotary-cmake-dev
+libgz-rotary-tools-dev
+libgz-rotary-utils-cli-dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
         id: ci
         uses: gazebo-tooling/action-gz-ci@noble
         with:
+          gzdev-project-name: rotary
           # codecov-enabled: true
           cppcheck-enabled: true
           cpplint-enabled: true


### PR DESCRIPTION
Use rotary alias packages for CI

Related to https://github.com/gazebo-tooling/release-tools/issues/1446