### PR TITLE
Loader: add LoadLib overload that captures errors via out-param

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,10 @@
 
 ### Gazebo Plugin 5.0.0 (20XX-XX-XX)
 
+1. Add `Loader::LoadLib` overload taking a `std::string *_errorMsg` out
+   parameter so callers can route plugin-loading errors through their own
+   logger instead of `std::cerr`.
+
 ## Gazebo Plugin 4.x
 
 ### Gazebo Plugin 4.0.0 (2025-08-25)

--- a/loader/include/gz/plugin/Loader.hh
+++ b/loader/include/gz/plugin/Loader.hh
@@ -144,6 +144,36 @@ namespace gz
       public: std::unordered_set<std::string> LoadLib(
                   const std::string &_pathToLibrary, bool _noDelete);
 
+      /// \brief Load a library at the given path, capturing any diagnostic
+      /// error message into a caller-provided string instead of writing it
+      /// to std::cerr.
+      ///
+      /// This is useful when callers want to route plugin-loading errors
+      /// through their own logging system (e.g., gz-common's `gzerr`).
+      /// On success, _errorMsg is left untouched. On failure, _errorMsg is
+      /// set to a human-readable description of the failure (which may
+      /// include the dlerror() text on POSIX systems) and nothing is
+      /// written to std::cerr. Pass nullptr for _errorMsg to keep the
+      /// historical behavior of writing to std::cerr.
+      ///
+      /// An empty returned set may indicate either that the library failed
+      /// to load or that it loaded successfully but exposed no plugins.
+      /// Inspect _errorMsg to disambiguate.
+      ///
+      /// \param[in] _pathToLibrary
+      ///   The path to a library
+      /// \param[in] _noDelete
+      ///   If true, RTLD_NODELETE will be used when loading the library.
+      /// \param[out] _errorMsg
+      ///   If non-null, on failure receives a description of the error and
+      ///   no message is written to std::cerr. If null, errors are reported
+      ///   to std::cerr (legacy behavior).
+      ///
+      /// \returns The set of plugins that have been loaded from the library
+      public: std::unordered_set<std::string> LoadLib(
+                  const std::string &_pathToLibrary, bool _noDelete,
+                  std::string *_errorMsg);
+
       /// \brief Instantiates a plugin for the given plugin name
       ///
       /// \param[in] _pluginNameOrAlias

--- a/loader/src/Loader.cc
+++ b/loader/src/Loader.cc
@@ -33,6 +33,25 @@
 #include <gz/plugin/detail/StaticRegistry.hh>
 #include <gz/plugin/utility.hh>
 
+namespace
+{
+  /// \brief Append a single-line diagnostic to _errorMsg if non-null;
+  /// otherwise write it to std::cerr (legacy behavior).
+  inline void ReportError(std::string *_errorMsg, const std::string &_line)
+  {
+    if (_errorMsg)
+    {
+      if (!_errorMsg->empty())
+        _errorMsg->push_back('\n');
+      _errorMsg->append(_line);
+    }
+    else
+    {
+      std::cerr << _line << std::endl;
+    }
+  }
+}
+
 namespace gz
 {
   namespace plugin
@@ -43,20 +62,29 @@ namespace gz
     {
       /// \brief Attempt to load a library at the given path.
       /// \param[in] _pathToLibrary The full path to the desired library
+      /// \param[in] _noDelete See Loader::LoadLib.
+      /// \param[out] _errorMsg If non-null, on failure receives the error
+      /// message and nothing is written to std::cerr. If null, errors are
+      /// written to std::cerr (legacy behavior).
       /// \return If a library exists at the given path, get a point to its dl
       /// handle. If the library does not exist, get a nullptr.
       public: std::shared_ptr<void> LoadLib(
-        const std::string &_pathToLibrary, bool _noDelete);
+        const std::string &_pathToLibrary, bool _noDelete,
+        std::string *_errorMsg);
 
       /// \brief Using a dl handle produced by LoadLib, extract the
       /// Info from the loaded library.
       /// \param[in] _dlHandle A handle produced by LoadLib
       /// \param[in] _pathToLibrary The path that the library was loaded from
       /// (used for debug purposes)
+      /// \param[out] _errorMsg If non-null, error messages are appended to
+      /// this string and nothing is written to std::cerr. If null, errors are
+      /// written to std::cerr (legacy behavior).
       /// \return All the Info provided by the loaded library.
       public: std::vector<Info> LoadPlugins(
         const std::shared_ptr<void> &_dlHandle,
-        const std::string &_pathToLibrary) const;
+        const std::string &_pathToLibrary,
+        std::string *_errorMsg) const;
 
       /// \sa Loader::ForgetLibrary()
       public: bool ForgetLibrary(void *_dlHandle);
@@ -140,17 +168,24 @@ namespace gz
     std::unordered_set<std::string> Loader::LoadLib(
         const std::string &_pathToLibrary)
     {
-      return this->LoadLib(_pathToLibrary, false);
+      return this->LoadLib(_pathToLibrary, false, nullptr);
     }
     /////////////////////////////////////////////////
     std::unordered_set<std::string> Loader::LoadLib(
         const std::string &_pathToLibrary, bool _noDelete)
     {
+      return this->LoadLib(_pathToLibrary, _noDelete, nullptr);
+    }
+    /////////////////////////////////////////////////
+    std::unordered_set<std::string> Loader::LoadLib(
+        const std::string &_pathToLibrary, bool _noDelete,
+        std::string *_errorMsg)
+    {
       std::unordered_set<std::string> newPlugins;
 
       // Attempt to load the library at this path
       const std::shared_ptr<void> &dlHandle =
-          this->dataPtr->LoadLib(_pathToLibrary, _noDelete);
+          this->dataPtr->LoadLib(_pathToLibrary, _noDelete, _errorMsg);
 
       // Quit early and return an empty set of plugin names if we did not
       // actually get a valid dlHandle.
@@ -161,7 +196,7 @@ namespace gz
 
       // Found a shared library, does it have the symbols we're looking for?
       std::vector<Info> loadedPlugins = this->dataPtr->LoadPlugins(
-            dlHandle, _pathToLibrary);
+            dlHandle, _pathToLibrary, _errorMsg);
 
       for (Info &plugin : loadedPlugins)
       {
@@ -428,7 +463,8 @@ namespace gz
 
     /////////////////////////////////////////////////
     std::shared_ptr<void> Loader::Implementation::LoadLib(
-        const std::string &_full_path, bool _noDelete)
+        const std::string &_full_path, bool _noDelete,
+        std::string *_errorMsg)
     {
       std::shared_ptr<void> dlHandlePtr;
 
@@ -451,8 +487,10 @@ namespace gz
       const char *loadError = dlerror();
       if (nullptr == dlHandle || nullptr != loadError)
       {
-        std::cerr << "Error while loading the library [" << _full_path << "]: "
-                  << loadError << std::endl;
+        std::ostringstream msg;
+        msg << "Error while loading the library [" << _full_path << "]: "
+            << (loadError ? loadError : "unknown error");
+        ReportError(_errorMsg, msg.str());
 
         // Just return a nullptr if the library could not be loaded. The
         // Loader::LoadLib(~) function will handle this gracefully.
@@ -525,7 +563,8 @@ namespace gz
     /////////////////////////////////////////////////
     std::vector<Info> Loader::Implementation::LoadPlugins(
         const std::shared_ptr<void> &_dlHandle,
-        const std::string& _pathToLibrary) const
+        const std::string& _pathToLibrary,
+        std::string *_errorMsg) const
     {
       std::vector<Info> loadedPlugins;
 
@@ -540,9 +579,11 @@ namespace gz
       // Does the library have the right symbol?
       if (nullptr == infoFuncPtr)
       {
-        std::cerr << "Library [" << _pathToLibrary << "] does not export any "
-                  << "plugins. The symbol [" << infoSymbol << "] is missing, "
-                  << "or it is not externally visible.\n";
+        std::ostringstream msg;
+        msg << "Library [" << _pathToLibrary << "] does not export any "
+            << "plugins. The symbol [" << infoSymbol << "] is missing, "
+            << "or it is not externally visible.";
+        ReportError(_errorMsg, msg.str());
 
         return loadedPlugins;
       }
@@ -594,31 +635,37 @@ namespace gz
         // We can call GzPluginHook(~) again with the
         // API version that it expects.
 
-        std::cerr << "The library [" << _pathToLibrary << "] is using an "
-                  << "incompatible version [" << version << "] of the "
-                  << "gz::plugin Info API. The version in this library "
-                  << "is [" << INFO_API_VERSION << "].\n";
+        std::ostringstream msg;
+        msg << "The library [" << _pathToLibrary << "] is using an "
+            << "incompatible version [" << version << "] of the "
+            << "gz::plugin Info API. The version in this library "
+            << "is [" << INFO_API_VERSION << "].";
+        ReportError(_errorMsg, msg.str());
         return loadedPlugins;
       }
 
       if (sizeof(Info) != size || alignof(Info) != alignment)
       {
-        std::cerr << "The plugin::Info size or alignment are not consistent "
-               << "with the expected values for the library [" << _pathToLibrary
-               << "]:\n -- size: expected " << sizeof(Info)
-               << " | received " << size << "\n -- alignment: expected "
-               << alignof(Info) << " | received " << alignment << "\n"
-               << " -- We will not be able to safely load plugins from that "
-               << "library.\n";
+        std::ostringstream msg;
+        msg << "The plugin::Info size or alignment are not consistent "
+            << "with the expected values for the library [" << _pathToLibrary
+            << "]:\n -- size: expected " << sizeof(Info)
+            << " | received " << size << "\n -- alignment: expected "
+            << alignof(Info) << " | received " << alignment << "\n"
+            << " -- We will not be able to safely load plugins from that "
+            << "library.";
+        ReportError(_errorMsg, msg.str());
 
         return loadedPlugins;
       }
 
       if (!allInfo)
       {
-        std::cerr << "The library [" << _pathToLibrary << "] failed to provide "
-                  << "gz::plugin Info for unknown reasons. Please report "
-                  << "this error as a bug!\n";
+        std::ostringstream msg;
+        msg << "The library [" << _pathToLibrary << "] failed to provide "
+            << "gz::plugin Info for unknown reasons. Please report "
+            << "this error as a bug!";
+        ReportError(_errorMsg, msg.str());
 
         return loadedPlugins;
       }

--- a/loader/src/Loader_TEST.cc
+++ b/loader/src/Loader_TEST.cc
@@ -18,11 +18,28 @@
 #include <gtest/gtest.h>
 
 #include <algorithm>
+#include <iostream>
+#include <sstream>
+#include <string>
 
 #include <gz/plugin/Loader.hh>
 #include <gz/plugin/config.hh>
 
 #include <gz/plugin/SpecializedPluginPtr.hh>
+
+namespace
+{
+  // RAII helper that redirects std::cerr to a stringstream for the lifetime
+  // of the object, restoring the original buffer on destruction.
+  class CerrCapture
+  {
+    public: CerrCapture() : oldBuf(std::cerr.rdbuf(captured.rdbuf())) {}
+    public: ~CerrCapture() { std::cerr.rdbuf(this->oldBuf); }
+    public: std::string str() const { return this->captured.str(); }
+    private: std::stringstream captured;
+    private: std::streambuf *oldBuf;
+  };
+}
 
 /////////////////////////////////////////////////
 TEST(Loader, InitialNoInterfacesImplemented)
@@ -90,6 +107,67 @@ TEST(Loader, DoubleLoad)
 
   loader.LoadLib(GzDummyPlugins_LIB);
   EXPECT_EQ(interfaceCount, loader.InterfacesImplemented().size());
+}
+
+/////////////////////////////////////////////////
+TEST(Loader, LoadLibCapturesDlopenErrorIntoOutParam)
+{
+  gz::plugin::Loader loader;
+  std::string errorMsg;
+  CerrCapture capture;
+
+  auto plugins = loader.LoadLib("/path/to/libDoesNotExist.so",
+                                /*_noDelete=*/false, &errorMsg);
+
+  EXPECT_TRUE(plugins.empty());
+  EXPECT_FALSE(errorMsg.empty())
+      << "Expected dlopen failure to populate the error string";
+  EXPECT_NE(std::string::npos,
+            errorMsg.find("/path/to/libDoesNotExist.so"))
+      << "Expected the failing path to appear in the error message, got: "
+      << errorMsg;
+  EXPECT_TRUE(capture.str().empty())
+      << "Expected std::cerr to be silent when an error string is provided, "
+      << "but got: " << capture.str();
+}
+
+/////////////////////////////////////////////////
+TEST(Loader, LoadLibLegacyOverloadsStillWriteToCerr)
+{
+  // The 1-arg and 2-arg overloads must keep writing to std::cerr when the
+  // load fails — that's the contract callers depended on before the
+  // out-param overload existed.
+  gz::plugin::Loader loader;
+
+  {
+    CerrCapture capture;
+    auto plugins = loader.LoadLib("/path/to/libDoesNotExist.so");
+    EXPECT_TRUE(plugins.empty());
+    EXPECT_FALSE(capture.str().empty())
+        << "Legacy 1-arg overload must still write to std::cerr";
+  }
+
+  {
+    CerrCapture capture;
+    auto plugins =
+        loader.LoadLib("/path/to/libDoesNotExist.so", /*_noDelete=*/true);
+    EXPECT_TRUE(plugins.empty());
+    EXPECT_FALSE(capture.str().empty())
+        << "Legacy 2-arg overload must still write to std::cerr";
+  }
+}
+
+/////////////////////////////////////////////////
+TEST(Loader, LoadLibSuccessLeavesErrorMsgUntouched)
+{
+  gz::plugin::Loader loader;
+  std::string errorMsg = "should not be cleared";
+
+  auto plugins = loader.LoadLib(GzDummyPlugins_LIB,
+                                /*_noDelete=*/false, &errorMsg);
+
+  EXPECT_LT(0u, plugins.size());
+  EXPECT_EQ("should not be cleared", errorMsg);
 }
 
 /////////////////////////////////////////////////


### PR DESCRIPTION
# 🎉 New feature

## Summary
`LoadLib` previously wrote every diagnostic — dlopen failure text, missing `GzPluginHook` symbol, version/ABI/size/alignment mismatches — directly to `std::cerr`, with no way for callers to redirect them. Higher-level consumers (e.g. gz-rendering's `RenderEngineManager`) use their own logger (`gzerr`) and ended up emitting a generic "couldn't load library" line while the actually-informative message — including glibc's "cannot allocate memory in static TLS block" — landed on a different sink and was dropped from log files.

Add a third overload:

```c++
    std::unordered_set<std::string> LoadLib(
        const std::string &_pathToLibrary, bool _noDelete,
        std::string *_errorMsg);
```

When `_errorMsg` is non-null, every diagnostic site appends to it (multi-line where appropriate) and `std::cerr` stays silent. When null, behavior is identical to before, so the two pre-existing overloads (which now delegate to this one with `nullptr`) keep their legacy contract and no existing caller is affected.

Bonus: callers can now disambiguate "load failed" from "loaded but no plugins" by inspecting `_errorMsg` after an empty result set — something the old API conflated.

Also tightens one latent footgun: the dlopen failure branch printed `loadError` unconditionally, but `dlerror()` can yield `nullptr` even when the surrounding condition fires. Now reports "unknown error" rather than dereferencing null.

Three unit tests cover:
  - out-param capture path (cerr stays silent),
  - legacy 1-arg / 2-arg overloads still route to cerr,
  - successful load leaves a pre-existing error string untouched.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the feature
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Opus 4.7

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.