### PR TITLE
Optimize Plugin copy

### DIFF
--- a/core/include/gz/plugin/Plugin.hh
+++ b/core/include/gz/plugin/Plugin.hh
@@ -182,7 +182,7 @@ namespace gz
       /// \brief Get or create an iterator to the std::map that holds pointers
       /// to the various interfaces provided by this plugin instance.
       private: InterfaceMap::iterator PrivateGetOrCreateIterator(
-          const std::string &_interfaceName);
+          const std::string &_interfaceName) const;
 
       class Implementation;
       GZ_UTILS_WARN_IGNORE__DLL_INTERFACE_MISSING

--- a/core/include/gz/plugin/SpecializedPlugin.hh
+++ b/core/include/gz/plugin/SpecializedPlugin.hh
@@ -148,11 +148,15 @@ namespace gz
 
       // Dev note (MXG): The privateSpecializedInterfaceIterator object must be
       // available to the user during their compile time, so it cannot be hidden
-      // using PIMPL. The iterator is const because it must always point to the
-      // same entry throughout its entire lifecycle.
+      // using PIMPL. The iterator is mutable because it may need to be
+      // re-initialized if the underlying plugin instance changes.
       /// \brief Iterator that points to the entry of the specialized interface
-      private:
-      const Plugin::InterfaceMap::iterator privateSpecializedInterfaceIterator;
+      private: mutable Plugin::InterfaceMap::iterator
+          privateSpecializedInterfaceIterator;
+
+      /// \brief Pointer to the instance that the iterator is currently
+      /// associated with.
+      private: mutable const void *privateLastInstancePtr = nullptr;
 
       /// \brief Default constructor
       protected: SpecializedPlugin();

--- a/core/include/gz/plugin/detail/SpecializedPlugin.hh
+++ b/core/include/gz/plugin/detail/SpecializedPlugin.hh
@@ -108,6 +108,15 @@ namespace gz
       #ifdef GZ_UNITTEST_SPECIALIZED_PLUGIN_ACCESS
       usedSpecializedInterfaceAccess = true;
       #endif
+
+      const void *currentInstance = this->PrivateGetInstancePtr().get();
+      if (currentInstance != this->privateLastInstancePtr)
+      {
+        this->privateSpecializedInterfaceIterator =
+            this->PrivateGetOrCreateIterator(typeid(SpecInterface).name());
+        this->privateLastInstancePtr = currentInstance;
+      }
+
       return static_cast<SpecInterface*>(
             this->privateSpecializedInterfaceIterator->second);
     }
@@ -129,6 +138,15 @@ namespace gz
       #ifdef GZ_UNITTEST_SPECIALIZED_PLUGIN_ACCESS
       usedSpecializedInterfaceAccess = true;
       #endif
+
+      const void *currentInstance = this->PrivateGetInstancePtr().get();
+      if (currentInstance != this->privateLastInstancePtr)
+      {
+        this->privateSpecializedInterfaceIterator =
+            this->PrivateGetOrCreateIterator(typeid(SpecInterface).name());
+        this->privateLastInstancePtr = currentInstance;
+      }
+
       return static_cast<SpecInterface*>(
             this->privateSpecializedInterfaceIterator->second);
     }
@@ -150,17 +168,23 @@ namespace gz
       #ifdef GZ_UNITTEST_SPECIALIZED_PLUGIN_ACCESS
       usedSpecializedInterfaceAccess = true;
       #endif
+
+      const void *currentInstance = this->PrivateGetInstancePtr().get();
+      if (currentInstance != this->privateLastInstancePtr)
+      {
+        this->privateSpecializedInterfaceIterator =
+            this->PrivateGetOrCreateIterator(typeid(SpecInterface).name());
+        this->privateLastInstancePtr = currentInstance;
+      }
+
       return (nullptr != this->privateSpecializedInterfaceIterator->second);
     }
 
     /////////////////////////////////////////////////
     template <class SpecInterface>
     SpecializedPlugin<SpecInterface>::SpecializedPlugin()
-      : privateSpecializedInterfaceIterator(
-          this->PrivateGetOrCreateIterator(
-            typeid(SpecInterface).name()))
     {
-      // Do nothing
+      // Do nothing. We use lazy initialization for the iterator.
     }
 
     namespace detail

--- a/core/src/Plugin.cc
+++ b/core/src/Plugin.cc
@@ -119,8 +119,11 @@ namespace gz
         // This would break any specialized plugins that provide instant access
         // to specialized interfaces. Instead, we simply overwrite the map
         // entries with a nullptr.
-        for (auto &entry : this->interfaces)
-          entry.second = nullptr;
+        //
+        // However, if this Implementation is being cleared, we should also
+        // ensure we aren't affecting other wrappers that might be sharing
+        // this map. We'll give this implementation a fresh map.
+        this->interfaces = std::make_shared<Plugin::InterfaceMap>();
       }
 
       /// \brief Initialize this object by creating a new plugin instance from
@@ -182,7 +185,7 @@ namespace gz
           // entry.second: function which casts the loadedInstance pointer to
           //               the correct location of the interface within the
           //               plugin
-          this->interfaces[entry.first] =
+          (*this->interfaces)[entry.first] =
               entry.second(this->loadedInstancePtr.get());
         }
       }
@@ -191,8 +194,6 @@ namespace gz
       /// \param[in] _other Another instance of a Plugin::Implementation object
       public: void Copy(const Implementation *_other)
       {
-        this->Clear();
-
         if (!_other)
         {
           // LCOV_EXCL_START
@@ -205,19 +206,12 @@ namespace gz
           // LCOV_EXCL_STOP
         }
 
+        if (this == _other)
+          return;
+
         this->loadedInstancePtr = _other->loadedInstancePtr;
         this->info = _other->info;
-
-        if (this->loadedInstancePtr)
-        {
-          for (const auto &entry : _other->interfaces)
-          {
-            // entry.first:  name of the interface
-            // entry.second: pointer to the location of that interface within
-            //               the plugin instance
-            this->interfaces[entry.first] = entry.second;
-          }
-        }
+        this->interfaces = _other->interfaces;
       }
 
       /// \brief Initialize this object using another instance
@@ -230,6 +224,7 @@ namespace gz
       {
         this->loadedInstancePtr = _instance;
         this->info = _info;
+        this->interfaces = std::make_shared<Plugin::InterfaceMap>();
 
         if (this->loadedInstancePtr)
         {
@@ -253,7 +248,7 @@ namespace gz
             // entry.second: function which casts the loadedInstance pointer to
             //               the correct location of the interface within the
             //               plugin
-            this->interfaces[entry.first] =
+            (*this->interfaces)[entry.first] =
                 entry.second(this->loadedInstancePtr.get());
           }
         }
@@ -275,7 +270,8 @@ namespace gz
       // characters) and a relatively small number of entries in the set (5-20
       // entries). Those conditions match our expected use case here. In fact,
       // ordered lookup can sometimes outperform unordered in these conditions.
-      public: Plugin::InterfaceMap interfaces;
+      public: std::shared_ptr<Plugin::InterfaceMap> interfaces =
+          std::make_shared<Plugin::InterfaceMap>();
 
       /// \brief shared_ptr which manages the lifecycle of the plugin instance.
       ///
@@ -316,7 +312,7 @@ namespace gz
         return (info->demangledInterfaces.count(_interfaceName) != 0);
       }
 
-      return (this->dataPtr->interfaces.count(_interfaceName) != 0);
+      return (this->dataPtr->interfaces->count(_interfaceName) != 0);
     }
 
     //////////////////////////////////////////////////
@@ -339,8 +335,8 @@ namespace gz
     void *Plugin::PrivateQueryInterface(
         const std::string &_interfaceName) const
     {
-      const auto &it = this->dataPtr->interfaces.find(_interfaceName);
-      if (this->dataPtr->interfaces.end() == it)
+      const auto &it = this->dataPtr->interfaces->find(_interfaceName);
+      if (this->dataPtr->interfaces->end() == it)
         return nullptr;
 
       return it->second;
@@ -390,11 +386,11 @@ namespace gz
 
     //////////////////////////////////////////////////
     Plugin::InterfaceMap::iterator Plugin::PrivateGetOrCreateIterator(
-        const std::string &_interfaceName)
+        const std::string &_interfaceName) const
     {
       // We want to use the insert function here to avoid accidentally
       // overwriting a value which might exist at the desired map key.
-      return this->dataPtr->interfaces.insert(
+      return this->dataPtr->interfaces->insert(
             std::make_pair(_interfaceName, nullptr)).first;
     }
 


### PR DESCRIPTION
# 🎉 New feature

Performance improvement for gz-plugin.
:warning: This has been completely AI generated, the process was profile, find the bottleneck from flamegraph, get a backtrace through gdb, feed it into the AI and have it come up with possible optimizations. I do not really understand this code :warning: 

## Summary

What I _do_ know is that the creation and destruction of gz-plugin instances was taking a significant amount of time (this is after all other optimizations). This was specifically because the `interfaces` member variable is a `std::map<std::string, void*>`, its creation required a dynamic allocation for each node, together with (possibly, depending on SSO) an allocation for a string on each node. Its destruction required iterating through the map and destroy all nodes one by one.
The bottleneck happened in gz-physics, so if we are planning to skip it and make it a system this won't be relevant anymore.
I can follow up with some backtraces / flamegraphs if there is any sort of confidence in reviewing / merging this.

## Backport Policy
- [ ] This is safe to backport to the following versions:
    - [ ] Jetty
    - [ ] Ionic
    - [ ] Harmonic
    - [ ] Fortress
- [ ] This **should not** be backported
- [x] I am not sure
- [ ] Other (fill in yourself)
## Test it

TODO, will involve running a simulation and getting its RTF.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the feature
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Gemini 3

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.